### PR TITLE
Input Block Updates

### DIFF
--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -95,7 +95,7 @@ defmodule BlockBox do
     Optional parameters ->
       optional: Boolean \\ false
   """
-  @spec input(map(), String.t(), String.t(), list()) :: map()
+  @spec input(String.t(), map(), String.t(), list()) :: map()
   def input(text, element, block_id, klist \\ []) do
     optional = Keyword.get(klist, :optional, false)
     hint = Keyword.get(klist, :hint, false)

--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -145,16 +145,18 @@ defmodule BlockBox do
       type: String
     Optional keys ->
       accessory: other block
-      block_id: String
+      block_id: String,
+      text_type: String
   """
   @spec section(String.t(), keyword()) :: map()
   def section(text, klist \\ []) do
     acc = Keyword.get(klist, :accessory, false)
     bid = Keyword.get(klist, :block_id, false)
+    text_type = Keyword.get(klist, :text_type, "plain_text")
 
     result = %{
       "type" => "section",
-      "text" => text_info(text)
+      "text" => text_info(text, type: text_type)
     }
 
     result_bid =

--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -20,6 +20,7 @@ defmodule BlockBox do
       use BlockBox
     ```
   """
+
   @doc """
     Function that generates a text struct
     Required parameter ->
@@ -38,12 +39,10 @@ defmodule BlockBox do
       "text" => text
     }
 
-    case emoji_bool,
-      do:
-        (
-          false -> result
-          _ -> Map.put(result, "emoji", emoji_bool)
-        )
+    case emoji_bool do
+      false -> result
+      _ -> Map.put(result, "emoji", emoji_bool)
+    end
   end
 
   @doc """
@@ -54,7 +53,7 @@ defmodule BlockBox do
   """
   @spec generate_option(String.t(), String.t()) :: map()
   def generate_option(display_text, opt_value) do
-    option = %{
+    %{
       "text" => text_info(display_text, type: "plain_text", emoji_bool: true),
       "value" => opt_value
     }
@@ -75,8 +74,8 @@ defmodule BlockBox do
     Required parameters ->
       placeholder: String
       multiline_bool: Boolean
-    Optional keys ->  
-      action_id: String 
+    Optional keys ->
+      action_id: String
   """
   @spec plain_text_input(String.t(), boolean()) :: map()
   def plain_text_input(placeholder, multiline) do
@@ -93,25 +92,31 @@ defmodule BlockBox do
       text: String
       element: map()
       block_id: String
-    Optional parameters -> 
+    Optional parameters ->
       optional: Boolean \\ false
   """
-  @spec input(String.t(), map(), String.t(), list()) :: map()
-  def input(text, elem, block_id, klist \\ []) do
+  @spec input(map(), String.t(), String.t(), list()) :: map()
+  def input(text, element, block_id, klist \\ []) do
     optional = Keyword.get(klist, :optional, false)
+    hint = Keyword.get(klist, :hint, false)
+
     input = %{
       "type" => "input",
-      "element" => elem,
+      "element" => element,
       "block_id" => block_id,
       "label" => text_info(text, type: "plain_text", emoji_bool: true)
     }
-    case optional,
-      do:
-        (
-          false -> input
-          _ -> Map.put(input, "optional", true)
-        )
 
+    input =
+      case optional do
+        false -> input
+        _ -> Map.put(input, "optional", true)
+      end
+
+    case hint do
+      false -> input
+      _ -> Map.put(input, "hint", text_info(hint))
+    end
   end
 
   @doc """
@@ -153,19 +158,15 @@ defmodule BlockBox do
     }
 
     result_bid =
-      case bid,
-        do:
-          (
-            false -> result
-            _ -> Map.put(result, "block_id", bid)
-          )
+      case bid do
+        false -> result
+        _ -> Map.put(result, "block_id", bid)
+      end
 
-    case acc,
-      do:
-        (
-          false -> result_bid
-          _ -> Map.put(result_bid, "accessory", acc)
-        )
+    case acc do
+      false -> result_bid
+      _ -> Map.put(result_bid, "accessory", acc)
+    end
   end
 
   @doc """
@@ -201,12 +202,10 @@ defmodule BlockBox do
       "options" => options
     }
 
-    case initial,
-      do:
-        (
-          false -> result
-          _ -> Map.put(result, "initial_option", Enum.at(options, initial))
-        )
+    case initial do
+      false -> result
+      _ -> Map.put(result, "initial_option", Enum.at(options, initial))
+    end
   end
 
   @doc """
@@ -230,12 +229,12 @@ defmodule BlockBox do
       text: String
       value: String
   """
-  @spec button_block(String.t(), String.t()) :: map()
-  def button_block(text, value) do
+  @spec button_block(String.t(), String.t(), String.t()) :: map()
+  def button_block(text, value, type \\ "mrkdwn") do
     %{
       "type" => "button",
       "text" => %{
-        "type" => "plain_text",
+        "type" => type,
         "text" => text
       },
       "value" => value
@@ -265,11 +264,11 @@ defmodule BlockBox do
     Enum.reduce(list_maps, %{}, fn {k, v}, acc ->
       result = _get_val(v)
 
-      case is_list(result) do
-        true ->
-          case result, do: ([head | []] -> Map.put(acc, k, head); [head | tail] -> Map.put(acc, k, result); [] -> acc)
-        false ->
-          acc
+      case result do
+        [head | []] -> Map.put(acc, k, head)
+        [_head | _tail] -> Map.put(acc, k, result)
+        [] -> acc
+        _ -> acc
       end
     end)
   end
@@ -277,11 +276,10 @@ defmodule BlockBox do
   defp _get_val(list_val) when is_list(list_val) do
     Enum.reduce(list_val, [], fn v, acc ->
       result_val = _get_val(v)
+
       case result_val do
-        nil -> 
-          acc
-        _ -> 
-          acc ++ _get_val(v)
+        nil -> acc
+        _ -> acc ++ _get_val(v)
       end
     end)
   end
@@ -290,24 +288,20 @@ defmodule BlockBox do
     val = Map.get(map_val, "value", false)
 
     val =
-      case val,
-        do:
-          (
-            false -> Map.get(map_val, "selected_date", false)
-            _ -> val
-          )
+      case val do
+        false -> Map.get(map_val, "selected_date", false)
+        _ -> val
+      end
 
     val =
-      case val,
-        do:
-          (
-            false -> Map.get(map_val, "selected_users", false)
-            _ -> val
-          )
+      case val do
+        false -> Map.get(map_val, "selected_users", false)
+        _ -> val
+      end
 
     case val do
       false ->
-        Enum.reduce(map_val, [], fn {k, v}, acc ->
+        Enum.reduce(map_val, [], fn {_k, v}, acc ->
           vals = _get_val(v)
 
           case vals == [] or vals == nil do
@@ -321,7 +315,7 @@ defmodule BlockBox do
     end
   end
 
-  defp _get_val(val) do
+  defp _get_val(_val) do
     nil
   end
 

--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -26,12 +26,12 @@ defmodule BlockBox do
     Required parameter ->
       text: String
     Optional keys in the keyword list are as follows with their default values
-      type: String \\ "mrkdwn"
+      type: String \\ "plain_text"
       emoji_bool: emoji \\ false
   """
   @spec text_info(String.t(), list()) :: map()
   def text_info(text, klist \\ []) do
-    type = Keyword.get(klist, :type, "mrkdwn")
+    type = Keyword.get(klist, :type, "plain_text")
     emoji_bool = Keyword.get(klist, :emoji_bool, false)
 
     result = %{
@@ -230,7 +230,7 @@ defmodule BlockBox do
       value: String
   """
   @spec button_block(String.t(), String.t(), String.t()) :: map()
-  def button_block(text, value, type \\ "mrkdwn") do
+  def button_block(text, value, type \\ "plain_text") do
     %{
       "type" => "button",
       "text" => %{

--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -115,7 +115,7 @@ defmodule BlockBox do
 
     case hint do
       false -> input
-      _ -> Map.put(input, "hint", text_info(hint))
+      _ -> Map.put(input, "hint", text_info(hint, type: "plain_text"))
     end
   end
 

--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -7,7 +7,7 @@ defmodule BlockBox do
     ```elixir
     def deps do
       [
-        {:blockbox, "~> 0.0.2"}
+        {:blockbox, "~> 0.2.0"}
       ]
     end
     ```

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Blockbox.MixProject do
       elixir: "~> 1.9",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      deps: deps,
+      deps: deps(),
       package: package(),
       docs: [
         main: "BlockBox",

--- a/test/blockbox_test.exs
+++ b/test/blockbox_test.exs
@@ -1,284 +1,337 @@
 defmodule BlockboxTest do
   use ExUnit.Case
   use BlockBox
+
   @submission_with_optionals %{
-    "attachments" => %{"qtgL" => %{"type" => "multi_static_select", "selected_options" => [
-      %{"value" => "1"}, %{"value" => "2"}]}},
-  "description" => %{
-    "42NY" => %{"type" => "plain_text_input", "value" => "test-123"}
-  },
-  "labels" => %{
-    "21FdK" => %{"type" => "plain_text_input", "value" => "test-123"}
-  },
-  "priority" => %{
-    "tV4vB" => %{
-      "selected_option" => %{
-        "text" => %{"emoji" => true, "text" => "P4", "type" => "plain_text"},
-        "value" => "9"
-      },
-      "type" => "static_select"
-    }
-  },
-  "summary" => %{
-    "BhPhP" => %{"type" => "plain_text_input", "value" => "test-123"}
+    "attachments" => %{
+      "qtgL" => %{
+        "type" => "multi_static_select",
+        "selected_options" => [%{"value" => "1"}, %{"value" => "2"}]
+      }
     },
-    "watchers" => %{"Po1WR" => %{"type" => "multi_users_select", "selected_users" => ["11221", "12D123"]}}
-  } 
-  @submission_without_optionals %{
-  "attachments" => %{"qtgL" => %{"type" => "multi_static_select"}},
-  "description" => %{
-    "42NY" => %{"type" => "plain_text_input", "value" => "test-123"}
-  },
-  "labels" => %{
-    "21FdK" => %{"type" => "plain_text_input", "value" => "test-123"}
-  },
-  "priority" => %{
-    "tV4vB" => %{
-      "selected_option" => %{
-        "text" => %{"emoji" => true, "text" => "P4", "type" => "plain_text"},
-        "value" => "9"
-      },
-      "type" => "static_select"
+    "description" => %{
+      "42NY" => %{"type" => "plain_text_input", "value" => "test-123"}
+    },
+    "labels" => %{
+      "21FdK" => %{"type" => "plain_text_input", "value" => "test-123"}
+    },
+    "priority" => %{
+      "tV4vB" => %{
+        "selected_option" => %{
+          "text" => %{"emoji" => true, "text" => "P4", "type" => "plain_text"},
+          "value" => "9"
+        },
+        "type" => "static_select"
+      }
+    },
+    "summary" => %{
+      "BhPhP" => %{"type" => "plain_text_input", "value" => "test-123"}
+    },
+    "watchers" => %{
+      "Po1WR" => %{"type" => "multi_users_select", "selected_users" => ["11221", "12D123"]}
     }
-  },
-  "summary" => %{
-    "BhPhP" => %{"type" => "plain_text_input", "value" => "test-123"}
+  }
+  @submission_without_optionals %{
+    "attachments" => %{"qtgL" => %{"type" => "multi_static_select"}},
+    "description" => %{
+      "42NY" => %{"type" => "plain_text_input", "value" => "test-123"}
+    },
+    "labels" => %{
+      "21FdK" => %{"type" => "plain_text_input", "value" => "test-123"}
+    },
+    "priority" => %{
+      "tV4vB" => %{
+        "selected_option" => %{
+          "text" => %{"emoji" => true, "text" => "P4", "type" => "plain_text"},
+          "value" => "9"
+        },
+        "type" => "static_select"
+      }
+    },
+    "summary" => %{
+      "BhPhP" => %{"type" => "plain_text_input", "value" => "test-123"}
     },
     "watchers" => %{"Po1WR" => %{"type" => "multi_users_select"}}
-  } 
+  }
   @elements %{
-              "text" => %{"text" => "Click Here", "type" => "plain_text"},
-              "type" => "button",
-              "value" => "output"
-            }
+    "text" => %{"text" => "Click Here", "type" => "plain_text"},
+    "type" => "button",
+    "value" => "output"
+  }
   @text_element %{"type" => "plain_text_input"}
   test "test button_block" do
-    assert button_block("Click Here", "output") == @elements 
+    assert button_block("Click Here", "output") == @elements
   end
+
   test "test context_actions as context" do
-    assert context_actions([@elements], "bid1") == %{"type" => "context", "block_id" => "bid1", "elements" => [@elements]} 
+    assert context_actions([@elements], "bid1") == %{
+             "type" => "context",
+             "block_id" => "bid1",
+             "elements" => [@elements]
+           }
   end
+
   test "test context_actions as actions" do
-    assert context_actions([@elements], "bid1", [elem_type: "actions"]) == %{"type" => "actions", "block_id" => "bid1", "elements" => [@elements]} 
+    assert context_actions([@elements], "bid1", elem_type: "actions") == %{
+             "type" => "actions",
+             "block_id" => "bid1",
+             "elements" => [@elements]
+           }
   end
+
   test "test date_block" do
-    assert date_block("11-10-19", "Input date") == %{:initial_date => "11-10-19", :placeholder => %{"emoji" => true, "text" => "Input date", "type" => "plain_text"}, :type => "datepicker"}
+    assert date_block("11-10-19", "Input date") == %{
+             :initial_date => "11-10-19",
+             :placeholder => %{"emoji" => true, "text" => "Input date", "type" => "plain_text"},
+             :type => "datepicker"
+           }
   end
+
   test "test divider" do
-    assert divider() == %{"type" => "divider"} 
+    assert divider() == %{"type" => "divider"}
   end
+
   test "test generate_option" do
     assert generate_option("option1", "opt_value") == %{
-              "text" => %{
-                "emoji" => true,
-                "text" => "option1",
-                "type" => "plain_text"
-              },
-              "value" => "opt_value"
-            } 
+             "text" => %{
+               "emoji" => true,
+               "text" => "option1",
+               "type" => "plain_text"
+             },
+             "value" => "opt_value"
+           }
   end
+
   test "test image_block" do
-    assert image_block("image_url", "alt text") == %{:alt_text => "alt text", :image_url => "image_url", :type => "image"} 
+    assert image_block("image_url", "alt text") == %{
+             :alt_text => "alt text",
+             :image_url => "image_url",
+             :type => "image"
+           }
   end
+
   test "input block not optional" do
     assert input("input box", @text_element, "bid2") == %{
-              "block_id" => "bid2",
-              "element" => %{"type" => "plain_text_input"},
-              "label" => %{
-                "emoji" => true,
-                "text" => "input box",
-                "type" => "plain_text"
-              },
-              "type" => "input"
-            } 
+             "block_id" => "bid2",
+             "element" => %{"type" => "plain_text_input"},
+             "label" => %{
+               "emoji" => true,
+               "text" => "input box",
+               "type" => "plain_text"
+             },
+             "type" => "input"
+           }
   end
+
   test "input block optional" do
-    assert input("input box", @text_element, "bid2", [optional: true]) == %{
-              "block_id" => "bid2",
-              "element" => %{"type" => "plain_text_input"},
-              "label" => %{
-                "emoji" => true,
-                "text" => "input box",
-                "type" => "plain_text"
-              },
-              "optional" => true,
-              "type" => "input"
-            }
+    assert input("input box", @text_element, "bid2", optional: true) == %{
+             "block_id" => "bid2",
+             "element" => %{"type" => "plain_text_input"},
+             "label" => %{
+               "emoji" => true,
+               "text" => "input box",
+               "type" => "plain_text"
+             },
+             "optional" => true,
+             "type" => "input"
+           }
   end
+
   test "test multi_user_select" do
     assert multi_select_users("multi_user_select") == %{
-              "placeholder" => %{
-                "emoji" => true,
-                "text" => "multi_user_select",
-                "type" => "plain_text"
-              },
-              "type" => "multi_users_select"
-            } 
+             "placeholder" => %{
+               "emoji" => true,
+               "text" => "multi_user_select",
+               "type" => "plain_text"
+             },
+             "type" => "multi_users_select"
+           }
   end
+
   test "test plain text input" do
     assert plain_text_input("placeholder", true) == %{
-              "multiline" => true,
-              "placeholder" => %{
-                "emoji" => true,
-                "text" => "placeholder",
-                "type" => "plain_text"
-              },
-              "type" => "plain_text_input"
-            } 
+             "multiline" => true,
+             "placeholder" => %{
+               "emoji" => true,
+               "text" => "placeholder",
+               "type" => "plain_text"
+             },
+             "type" => "plain_text_input"
+           }
   end
+
   test "test section" do
     assert section("section1") == %{
-              "text" => %{"text" => "section1", "type" => "mrkdwn"},
-              "type" => "section"
-            } 
+             "text" => %{"text" => "section1", "type" => "plain_text"},
+             "type" => "section"
+           }
   end
+
   test "test section with block id and accessory" do
-    assert section("section1", [accessory: @elements, block_id: "sect_block"]) == %{
-              "accessory" => %{
-                "text" => %{"text" => "Click Here", "type" => "plain_text"},
-                "type" => "button",
-                "value" => "output"
-              },
-              "block_id" => "sect_block",
-              "text" => %{"text" => "section1", "type" => "mrkdwn"},
-              "type" => "section"
-            } 
+    assert section("section1", accessory: @elements, block_id: "sect_block") == %{
+             "accessory" => %{
+               "text" => %{"text" => "Click Here", "type" => "plain_text"},
+               "type" => "button",
+               "value" => "output"
+             },
+             "block_id" => "sect_block",
+             "text" => %{"text" => "section1", "type" => "plain_text"},
+             "type" => "section"
+           }
   end
+
   test "test static select" do
-    assert static_select("static-select", Enum.map(1..5, fn num -> generate_option("#{num}", "#{num}") end)) == 
-%{
-              "options" => [
-                %{
-                  "text" => %{
-                    "emoji" => true,
-                    "text" => "1",
-                    "type" => "plain_text"
-                  },
-                  "value" => "1"
-                },
-                %{
-                  "text" => %{
-                    "emoji" => true,
-                    "text" => "2",
-                    "type" => "plain_text"
-                  },
-                  "value" => "2"
-                },
-                %{
-                  "text" => %{
-                    "emoji" => true,
-                    "text" => "3",
-                    "type" => "plain_text"
-                  },
-                  "value" => "3"
-                },
-                %{
-                  "text" => %{
-                    "emoji" => true,
-                    "text" => "4",
-                    "type" => "plain_text"
-                  },
-                  "value" => "4"
-                },
-                %{
-                  "text" => %{
-                    "emoji" => true,
-                    "text" => "5",
-                    "type" => "plain_text"
-                  },
-                  "value" => "5"
-                }
-              ],
-              "placeholder" => %{
-                "emoji" => true,
-                "text" => "static-select",
-                "type" => "plain_text"
-              },
-              "type" => "static_select"
-              }  
-  end 
+    assert static_select(
+             "static-select",
+             Enum.map(1..5, fn num -> generate_option("#{num}", "#{num}") end)
+           ) ==
+             %{
+               "options" => [
+                 %{
+                   "text" => %{
+                     "emoji" => true,
+                     "text" => "1",
+                     "type" => "plain_text"
+                   },
+                   "value" => "1"
+                 },
+                 %{
+                   "text" => %{
+                     "emoji" => true,
+                     "text" => "2",
+                     "type" => "plain_text"
+                   },
+                   "value" => "2"
+                 },
+                 %{
+                   "text" => %{
+                     "emoji" => true,
+                     "text" => "3",
+                     "type" => "plain_text"
+                   },
+                   "value" => "3"
+                 },
+                 %{
+                   "text" => %{
+                     "emoji" => true,
+                     "text" => "4",
+                     "type" => "plain_text"
+                   },
+                   "value" => "4"
+                 },
+                 %{
+                   "text" => %{
+                     "emoji" => true,
+                     "text" => "5",
+                     "type" => "plain_text"
+                   },
+                   "value" => "5"
+                 }
+               ],
+               "placeholder" => %{
+                 "emoji" => true,
+                 "text" => "static-select",
+                 "type" => "plain_text"
+               },
+               "type" => "static_select"
+             }
+  end
+
   test "test multi select with initial" do
-    assert static_select("static-select", Enum.map(1..5, fn num -> generate_option("#{num}", "#{num}") end), [initial: 0, type: "multi-select"]) == %{
-              "initial_option" => %{
-                "text" => %{
-                  "emoji" => true,
-                  "text" => "1",
-                  "type" => "plain_text"
-                },
-                "value" => "1"
-              },
-              "options" => [
-                %{
-                  "text" => %{
-                    "emoji" => true,
-                    "text" => "1",
-                    "type" => "plain_text"
-                  },
-                  "value" => "1"
-                },
-                %{
-                  "text" => %{
-                    "emoji" => true,
-                    "text" => "2",
-                    "type" => "plain_text"
-                  },
-                  "value" => "2"
-                },
-                %{
-                  "text" => %{
-                    "emoji" => true,
-                    "text" => "3",
-                    "type" => "plain_text"
-                  },
-                  "value" => "3"
-                },
-                %{
-                  "text" => %{
-                    "emoji" => true,
-                    "text" => "4",
-                    "type" => "plain_text"
-                  },
-                  "value" => "4"
-                },
-                %{
-                  "text" => %{
-                    "emoji" => true,
-                    "text" => "5",
-                    "type" => "plain_text"
-                  },
-                  "value" => "5"
-                }
-              ],
-              "placeholder" => %{
-                "emoji" => true,
-                "text" => "static-select",
-                "type" => "plain_text"
-              },
-              "type" => "multi-select"
-            } 
+    assert static_select(
+             "static-select",
+             Enum.map(1..5, fn num -> generate_option("#{num}", "#{num}") end),
+             initial: 0,
+             type: "multi-select"
+           ) == %{
+             "initial_option" => %{
+               "text" => %{
+                 "emoji" => true,
+                 "text" => "1",
+                 "type" => "plain_text"
+               },
+               "value" => "1"
+             },
+             "options" => [
+               %{
+                 "text" => %{
+                   "emoji" => true,
+                   "text" => "1",
+                   "type" => "plain_text"
+                 },
+                 "value" => "1"
+               },
+               %{
+                 "text" => %{
+                   "emoji" => true,
+                   "text" => "2",
+                   "type" => "plain_text"
+                 },
+                 "value" => "2"
+               },
+               %{
+                 "text" => %{
+                   "emoji" => true,
+                   "text" => "3",
+                   "type" => "plain_text"
+                 },
+                 "value" => "3"
+               },
+               %{
+                 "text" => %{
+                   "emoji" => true,
+                   "text" => "4",
+                   "type" => "plain_text"
+                 },
+                 "value" => "4"
+               },
+               %{
+                 "text" => %{
+                   "emoji" => true,
+                   "text" => "5",
+                   "type" => "plain_text"
+                 },
+                 "value" => "5"
+               }
+             ],
+             "placeholder" => %{
+               "emoji" => true,
+               "text" => "static-select",
+               "type" => "plain_text"
+             },
+             "type" => "multi-select"
+           }
   end
+
   test "test text info" do
-    assert text_info("text1") == %{"text" => "text1", "type" => "mrkdwn"}
+    assert text_info("text1") == %{"text" => "text1", "type" => "plain_text"}
   end
+
   test "test text info with plain text type and emojis to true" do
-    assert text_info("text1", [type: "plain_text", emoji_bool: true]) == %{"text" => "text1", "type" => "plain_text", "emoji" => true}
+    assert text_info("text1", type: "plain_text", emoji_bool: true) == %{
+             "text" => "text1",
+             "type" => "plain_text",
+             "emoji" => true
+           }
   end
+
   test "test get_submission_values with optionals" do
     assert get_submission_values(@submission_with_optionals) == %{
-              "attachments" => ["1", "2"],
-              "description" => "test-123",
-              "labels" => "test-123",
-              "priority" => "9",
-              "summary" => "test-123",
-              "watchers" => ["11221", "12D123"]
-            } 
+             "attachments" => ["1", "2"],
+             "description" => "test-123",
+             "labels" => "test-123",
+             "priority" => "9",
+             "summary" => "test-123",
+             "watchers" => ["11221", "12D123"]
+           }
   end
+
   test "test get_submission_values without optionals" do
     assert get_submission_values(@submission_without_optionals) == %{
-              "description" => "test-123",
-              "labels" => "test-123",
-              "priority" => "9",
-              "summary" => "test-123",
-            } 
+             "description" => "test-123",
+             "labels" => "test-123",
+             "priority" => "9",
+             "summary" => "test-123"
+           }
   end
 end


### PR DESCRIPTION
adding `:hint` option to input blocks
added `:text_type` option to section (allows you to over-ride the default of text_info)
general code reformatting
defaults text type to `plain_text` whenever possible