### PR TITLE
V1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A tool used to generate slack UI blocks using elixir defined functions.
 ```elixir
 def deps do
   [
-    {:blockbox, "~> 1.0.0"}
+    {:blockbox, "~> 1.1.0"}
   ]
 end
 ```

--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -80,16 +80,16 @@ defmodule BlockBox do
     ```
   """
   @spec get_submission_values(map(), :action_id | :block_id) :: map()
-  def get_submission_values(block_map, type \\ :action_id)
+  def get_submission_values(values_payload, type \\ :action_id)
 
-  def get_submission_values(block_map, :action_id) do
-    Enum.reduce(block_map, %{}, fn {_k, v}, acc ->
+  def get_submission_values(values_payload, :action_id) do
+    Enum.reduce(values_payload, %{}, fn {_k, v}, acc ->
       Map.merge(acc, map_values(v))
     end)
   end
 
-  def get_submission_values(submission_payload, :block_id) do
-    map_values(submission_payload)
+  def get_submission_values(values_payload, :block_id) do
+    map_values(values_payload)
   end
 
   defp map_values(payload) do

--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -25,10 +25,65 @@ defmodule BlockBox do
 
   @doc """
   A quality-of-life function that parses the view response payload to extract the block_id:block_value key-value pairs
+    
+    iex> submission_with_optionals = %{
+    ...>  "attachments" => %{
+    ...>   "qtgL" => %{
+    ...>      "type" => "multi_static_select",
+    ...>      "selected_options" => [%{"value" => "1"}, %{"value" => "2"}]
+    ...>    }
+    ...>  },
+    ...>  "description" => %{
+    ...>    "42NY" => %{"type" => "plain_text_input", "value" => "test-123"}
+    ...>  },
+    ...>  "labels" => %{
+    ...>    "21FdK" => %{"type" => "plain_text_input", "value" => "test-123"}
+    ...>  },
+    ...>  "priority" => %{
+    ...>    "tV4vB" => %{
+    ...>      "selected_option" => %{
+    ...>        "text" => %{"emoji" => true, "text" => "P4", "type" => "plain_text"},
+    ...>        "value" => "9"
+    ...>      },
+    ...>      "type" => "static_select"
+    ...>    }
+    ...>  },
+    ...>  "summary" => %{
+    ...>    "BhPhP" => %{"type" => "plain_text_input", "value" => "test-123"}
+    ...>  },
+    ...>  "watchers" => %{
+    ...>    "Po1WR" => %{"type" => "multi_users_select", "selected_users" => ["11221", "12D123"]}
+    ...>  }
+    ...>} 
+    iex> get_submission_values(submission_with_optionals)
+    %{
+      "21FdK" => "test-123",
+      "42NY" => "test-123",
+      "BhPhP" => "test-123",
+      "Po1WR" => ["11221", "12D123"],
+      "qtgL" => ["1", "2"],
+      "tV4vB" => "9"
+    }    
+    iex> get_submission_values(submission_with_optionals, :block_id)
+    %{
+      "21FdK" => "test-123",
+      "42NY" => "test-123",
+      "BhPhP" => "test-123",
+      "Po1WR" => ["11221", "12D123"],
+      "qtgL" => ["1", "2"],
+      "tV4vB" => "9"
+    }    
   """
-  @spec get_submission_values(map()) :: map()
-  def get_submission_values(list_maps) do
-    Enum.reduce(list_maps, %{}, fn {k, v}, acc ->
+  @spec get_submission_values(map(), :action_id | :block_id) :: map()
+  def get_submission_values(block_map, type \\ :action_id)
+  def get_submission_values(block_map, :action_id) do
+    Enum.reduce(block_map, %{}, fn {k, v}, acc ->
+      Map.merge(acc, get_submission_values(v, :block_id))
+    end)
+  end
+
+  def get_submission_values(action_maps, :block_id) do
+    Enum.reduce(action_maps, %{}, fn {k, v}, acc ->
       result = _get_val(v)
 
       case result do

--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -6,7 +6,7 @@ defmodule BlockBox do
   ```elixir
   def deps do
     [
-      {:blockbox, "~> 1.0.0"}
+      {:blockbox, "~> 1.1.0"}
     ]
   end
   ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Blockbox.MixProject do
   def project do
     [
       app: :blockbox,
-      version: "1.0.0",
+      version: "1.1.0",
       elixir: "~> 1.9",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Blockbox.MixProject do
+defmodule BlockBox.MixProject do
   use Mix.Project
 
   def project do

--- a/test/blockbox_test.exs
+++ b/test/blockbox_test.exs
@@ -1,4 +1,4 @@
-defmodule BlockboxTest do
+defmodule BlockBoxTest do
   use ExUnit.Case, async: true
   doctest BlockBox
   use BlockBox
@@ -62,7 +62,7 @@ defmodule BlockboxTest do
   @text_element %{"type" => "plain_text_input"}
 
   test "test get_submission_values with optionals" do
-    assert get_submission_values(@submission_with_optionals) == %{
+    assert get_submission_values(@submission_with_optionals, :block_id) == %{
              "attachments" => ["1", "2"],
              "description" => "test-123",
              "labels" => "test-123",
@@ -73,7 +73,7 @@ defmodule BlockboxTest do
   end
 
   test "test get_submission_values without optionals" do
-    assert get_submission_values(@submission_without_optionals) == %{
+    assert get_submission_values(@submission_without_optionals, :block_id) == %{
              "description" => "test-123",
              "labels" => "test-123",
              "priority" => "9",

--- a/test/blockbox_test.exs
+++ b/test/blockbox_test.exs
@@ -1,5 +1,6 @@
 defmodule BlockboxTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+  doctest BlockBox
   use BlockBox
 
   @submission_with_optionals %{


### PR DESCRIPTION
Updated: `BlockBox.get_submission_values/2` and it's documentation, defaulting it to `action_id` rather than `block_id`.