### PR TITLE
Fix for adding a single option in initial options

### DIFF
--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -57,11 +57,14 @@ defmodule BlockBox.Utils do
         no_processing_required ->
           no_processing_required
       end
-
-    case items do
-      [_len1] -> Keyword.put(opts, put_opt, hd(items))
-      _ -> Keyword.put(opts, put_opt, items)
+      
+    case put_opt do
+      :initial_option ->
+        Keyword.put(opts, put_opt, hd(items))
+      _ ->
+        Keyword.put(opts, put_opt, items)
     end
+        
   end
 
   def today() do

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -40,6 +40,13 @@ defmodule UtilsTest do
              options: options
            ]
 
+    opts = [options: options, initial_options: [0]]
+
+    assert convert_initial_opts(opts) == [
+             initial_options: [%{text: "def", value: "hello"}],
+             options: options
+           ]
+
     opts = [option_groups: option_groups, initial_option: {0, 1}]
 
     assert convert_initial_opts(opts) == [
@@ -51,6 +58,13 @@ defmodule UtilsTest do
 
     assert convert_initial_opts(opts) == [
              initial_options: [%{text: "def", value: "hello"}, %{text: "abc", value: "world"}],
+             option_groups: option_groups
+           ]
+
+    opts = [option_groups: option_groups, initial_options: [{0, 0}]]
+
+    assert convert_initial_opts(opts) == [
+             initial_options: [%{text: "def", value: "hello"}],
              option_groups: option_groups
            ]
   end


### PR DESCRIPTION
Closes #8 

# Description

Fix for adding a single option in the initial options keyword list. A single initial option within initial options returned an element outside a list, slack wants an element within a list. Thus, for initial_option keyword I return the head of the list, and for initial options I return back the list.