### PR TITLE
V1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A tool used to generate slack UI blocks using elixir defined functions.
 ```elixir
 def deps do
   [
-    {:blockbox, "~> 1.1.1"}
+    {:blockbox, "~> 1.1.2"}
   ]
 end
 ```

--- a/lib/block_elements.ex
+++ b/lib/block_elements.ex
@@ -212,7 +212,7 @@ defmodule BlockBox.BlockElements do
   * `:initial_conversations` - list of slack conversation IDs, only available with [multi_conversations_select](https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select) type
   * `:initial_channels` - list of slack channel IDs, only available with [multi_channels_select](https://api.slack.com/reference/block-kit/block-elements#channel_multi_select) type
   * `:confirm` - `t:BlockBox.CompositionObjects.confirm_object/0`
-  * `:filter` - `t:BlockBox.CompositionObjects.filter_object/0`, only available with [multi_conversations_select](hthttps://api.slack.com/reference/block-kit/block-elements#conversation_multi_select) type
+  * `:filter` - `t:BlockBox.CompositionObjects.filter_object/0`, only available with [multi_conversations_select](https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select) type
   """
   @spec multi_select_menu(
           String.t() | CO.plain_text_object(),

--- a/lib/block_elements.ex
+++ b/lib/block_elements.ex
@@ -154,6 +154,8 @@ defmodule BlockBox.BlockElements do
   * `:initial_conversation` - slack conversation ID, only available with [conversations_select](https://api.slack.com/reference/block-kit/block-elements#conversation_select) type
   * `:initial_channel` -  slack channel ID, only available with [channels_select](https://api.slack.com/reference/block-kit/block-elements#channel_select) type
   * `:confirm` - `t:BlockBox.CompositionObjects.confirm_object/0`
+  * `:response_url_enabled` - boolean, only works with menus in inputs blocks and modals. only available with [conversations_select](https://api.slack.com/reference/block-kit/block-elements#conversation_select) and [channels_select](https://api.slack.com/reference/block-kit/block-elements#channel_select)
+  * `:filter` - `t:BlockBox.CompositionObjects.filter_object/0`, only available with [conversations_select](https://api.slack.com/reference/block-kit/block-elements#conversation_select) type
   """
   @spec select_menu(
           String.t() | CO.plain_text_object(),
@@ -190,6 +192,7 @@ defmodule BlockBox.BlockElements do
   * `:initial_conversations` - list of slack conversation IDs, only available with [multi_conversations_select](https://api.slack.com/reference/block-kit/block-elements#conversation_multi_select) type
   * `:initial_channels` - list of slack channel IDs, only available with [multi_channels_select](https://api.slack.com/reference/block-kit/block-elements#channel_multi_select) type
   * `:confirm` - `t:BlockBox.CompositionObjects.confirm_object/0`
+  * `:filter` - `t:BlockBox.CompositionObjects.filter_object/0`, only available with [multi_conversations_select](hthttps://api.slack.com/reference/block-kit/block-elements#conversation_multi_select) type
   """
   @spec multi_select_menu(
           String.t() | CO.plain_text_object(),

--- a/lib/block_elements.ex
+++ b/lib/block_elements.ex
@@ -139,6 +139,26 @@ defmodule BlockBox.BlockElements do
   end
 
   @doc """
+  Creates a [checkbox group element](https://api.slack.com/reference/block-kit/block-elements#checkboxes).
+
+  ## Options
+  Options are not included by default.
+  * `:initial_options` - list of `t:BlockBox.CompositionObjects.option_object/0`s, Also included is the ability to pass in a list of integers representing the index of the item you want to select in `:options`.
+  * `:confirm` - `t:BlockBox.CompositionObjects.confirm_object/0`
+  """
+  @spec checkboxes(String.t(), list(CO.option_object()), keyword()) :: map()
+  def checkboxes(action_id, options, opts \\ []) do
+    opts = Utils.convert_initial_opts(opts)
+
+    %{
+      type: "checkboxes",
+      action_id: action_id,
+      options: options
+    }
+    |> Map.merge(Enum.into(opts, %{}))
+  end
+
+  @doc """
   Creates a [select menu element](https://api.slack.com/reference/block-kit/block-elements#select).
 
   *ONLY ONE* of the following k/v pairs must be included in the options:

--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -6,7 +6,7 @@ defmodule BlockBox do
   ```elixir
   def deps do
     [
-      {:blockbox, "~> 1.1.1"}
+      {:blockbox, "~> 1.1.2"}
     ]
   end
   ```

--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -176,6 +176,7 @@ defmodule BlockBox do
       defdelegate overflow_menu(action_id, options, opts \\ []), to: BE
       defdelegate plain_text_input(action_id, opts \\ []), to: BE
       defdelegate radio_buttons(action_id, options, opts \\ []), to: BE
+      defdelegate checkboxes(action_id, options, opts \\ []), to: BE
       defdelegate select_menu(placeholder, type, action_id, opts \\ []), to: BE
       defdelegate multi_select_menu(placeholder, type, action_id, opts \\ []), to: BE
 

--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -158,6 +158,7 @@ defmodule BlockBox do
       defdelegate confirm_object(title, text, confirm \\ "Confirm", deny \\ "Deny"), to: CO
       defdelegate option_object(text, value, opts \\ []), to: CO
       defdelegate option_group_object(label, options), to: CO
+      defdelegate filter_object(options), to: CO
 
       # layout blocks
       defdelegate section(text, opts \\ []), to: LB

--- a/lib/composition_objects.ex
+++ b/lib/composition_objects.ex
@@ -30,6 +30,7 @@ defmodule BlockBox.CompositionObjects do
   @type option_object() :: %{
           required(:text) => text_object(),
           required(:value) => String.t(),
+          optional(:description) => String.t(),
           optional(:url) => String.t()
         }
 

--- a/lib/composition_objects.ex
+++ b/lib/composition_objects.ex
@@ -2,6 +2,9 @@ defmodule BlockBox.CompositionObjects do
   @moduledoc """
   Defines types and generator functions for all [composition objects](https://api.slack.com/reference/block-kit/composition-objects).
   """
+
+  alias BlockBox.Utils, as: Utils
+
   @type text_type() :: :plain_text | :mrkdwn
 
   @type text_object() :: %{
@@ -76,6 +79,7 @@ defmodule BlockBox.CompositionObjects do
   ## Options
   Options are not included by default.
   * `:url` - boolean, only available in overflow menus
+  * `:description` - String, max 75 chars
   """
   def option_object(text, value, opts \\ [])
 
@@ -86,6 +90,8 @@ defmodule BlockBox.CompositionObjects do
   end
 
   def option_object(text_object, value, opts) do
+    opts = Utils.convert_text_opts(opts, [:description])
+
     %{
       text: text_object,
       value: value

--- a/lib/composition_objects.ex
+++ b/lib/composition_objects.ex
@@ -110,7 +110,8 @@ defmodule BlockBox.CompositionObjects do
   end
 
   @doc """
-  Function that generates an [filter object](https://api.slack.com/reference/block-kit/composition-objects#filter_conversations) for conversation lists
+  Function that generates a [filter object](https://api.slack.com/reference/block-kit/composition-objects#filter_conversations) for conversation lists.
+
   All fields are optional but AT LEAST ONE MUST BE INCLUDED.
   ## Options
   Options are not included by default.

--- a/lib/composition_objects.ex
+++ b/lib/composition_objects.ex
@@ -35,6 +35,12 @@ defmodule BlockBox.CompositionObjects do
           required(:options) => list(option_object())
         }
 
+  @type filter_object() :: %{
+          optional(:include) => list(String.t()),
+          optional(:exclude_external_shared_channels) => boolean(),
+          exclude_bot_users => boolean()
+        }
+
   @doc """
   Function that generates a [text object](https://api.slack.com/reference/block-kit/composition-objects#text)
 
@@ -69,7 +75,7 @@ defmodule BlockBox.CompositionObjects do
   Function that generates an [option object](https://api.slack.com/reference/block-kit/composition-objects#option) for select menus
   ## Options
   Options are not included by default.
-  * `:url` - boolean, only availablein overflow menus
+  * `:url` - boolean, only available in overflow menus
   """
   def option_object(text, value, opts \\ [])
 
@@ -102,4 +108,18 @@ defmodule BlockBox.CompositionObjects do
       options: options
     }
   end
+
+  @doc """
+  Function that generates an [filter object](https://api.slack.com/reference/block-kit/composition-objects#filter_conversations) for conversation lists
+  All fields are optional but AT LEAST ONE MUST BE INCLUDED.
+  ## Options
+  Options are not included by default.
+  * `:include` - non empty list of strings from the following options: "im", "mpim", "private", "public"
+  * `:exclude_external_shared_channels` - boolean, defaults to false
+  * `:exclude_bot_users` - boolean, defaults to false
+  """
+  def filter_object(opts) do
+      Enum.into(opts, %{})
+  end
+
 end

--- a/lib/composition_objects.ex
+++ b/lib/composition_objects.ex
@@ -30,7 +30,7 @@ defmodule BlockBox.CompositionObjects do
   @type option_object() :: %{
           required(:text) => text_object(),
           required(:value) => String.t(),
-          optional(:description) => String.t(),
+          optional(:description) => plain_text_object(),
           optional(:url) => String.t()
         }
 

--- a/lib/composition_objects.ex
+++ b/lib/composition_objects.ex
@@ -38,7 +38,7 @@ defmodule BlockBox.CompositionObjects do
   @type filter_object() :: %{
           optional(:include) => list(String.t()),
           optional(:exclude_external_shared_channels) => boolean(),
-          exclude_bot_users => boolean()
+          optional(:exclude_bot_users) => boolean()
         }
 
   @doc """
@@ -119,7 +119,6 @@ defmodule BlockBox.CompositionObjects do
   * `:exclude_bot_users` - boolean, defaults to false
   """
   def filter_object(opts) do
-      Enum.into(opts, %{})
+    Enum.into(opts, %{})
   end
-
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -57,14 +57,14 @@ defmodule BlockBox.Utils do
         no_processing_required ->
           no_processing_required
       end
-      
+
     case put_opt do
       :initial_option ->
         Keyword.put(opts, put_opt, hd(items))
+
       _ ->
         Keyword.put(opts, put_opt, items)
     end
-        
   end
 
   def today() do

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -57,11 +57,14 @@ defmodule BlockBox.Utils do
         no_processing_required ->
           no_processing_required
       end
-
-    case items do
-      [_len1] -> Keyword.put(opts, put_opt, hd(items))
-      _ -> Keyword.put(opts, put_opt, items)
+      
+    case put_opt do
+      :initial_option ->
+        Keyword.put(opts, put_opt, hd(items))
+      _ ->
+        Keyword.put(opts, put_opt, items)
     end
+        
   end
 
   def today() do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule BlockBox.MixProject do
   def project do
     [
       app: :blockbox,
-      version: "1.1.1",
+      version: "1.1.2",
       elixir: "~> 1.9",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/block_elements_test.exs
+++ b/test/block_elements_test.exs
@@ -64,6 +64,10 @@ defmodule BlockBox.BlockElementsTest do
     assert BE.radio_buttons("id", []) == %{action_id: "id", options: [], type: "radio_buttons"}
   end
 
+  test "checkboxes" do
+    assert BE.checkboxes("id", []) == %{action_id: "id", options: [], type: "checkboxes"}
+  end
+
   test "select_menu" do
     assert BE.select_menu("placeholder", :static_select, "id") == %{
              action_id: "id",

--- a/test/composition_objects_test.exs
+++ b/test/composition_objects_test.exs
@@ -30,4 +30,18 @@ defmodule BlockBox.CompositionObectsTest do
              options: [%{text: %{text: "text", type: :plain_text}, value: "value"}]
            }
   end
+
+  test "filter_object" do
+    options = [
+      include: ["private"],
+      exclude_external_shared_channels: true,
+      exclude_bot_users: false
+    ]
+
+    assert CO.filter_object(options) == %{
+             include: ["private"],
+             exclude_external_shared_channels: true,
+             exclude_bot_users: false
+           }
+  end
 end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -40,6 +40,13 @@ defmodule UtilsTest do
              options: options
            ]
 
+    opts = [options: options, initial_options: [0]]
+
+    assert convert_initial_opts(opts) == [
+             initial_options: [%{text: "def", value: "hello"}],
+             options: options
+           ]
+
     opts = [option_groups: option_groups, initial_option: {0, 1}]
 
     assert convert_initial_opts(opts) == [
@@ -51,6 +58,13 @@ defmodule UtilsTest do
 
     assert convert_initial_opts(opts) == [
              initial_options: [%{text: "def", value: "hello"}, %{text: "abc", value: "world"}],
+             option_groups: option_groups
+           ]
+
+    opts = [option_groups: option_groups, initial_options: [{0, 0}]]
+
+    assert convert_initial_opts(opts) == [
+             initial_options: [%{text: "def", value: "hello"}],
              option_groups: option_groups
            ]
   end


### PR DESCRIPTION
- fixes issue #8 (courtesy of @ssajnani)
- adds support for `checkboxes` block element (solves issue #9)
- adds support for new `filter` composition object
- updates docs for `select_menu` to include a new option
- adds support for new `description` option for `option object` type