### PR TITLE
adds support for channel selector on get_submission_values

### DIFF
--- a/lib/blockbox.ex
+++ b/lib/blockbox.ex
@@ -131,6 +131,12 @@ defmodule BlockBox do
         _ -> val
       end
 
+    val =
+      case val do
+        false -> Map.get(map_val, "selected_channel", false)
+        _ -> val
+      end
+
     case val do
       false ->
         Enum.reduce(map_val, [], fn {_k, v}, acc ->


### PR DESCRIPTION
When using Slack's [conversation select](https://api.slack.com/reference/block-kit/block-elements#conversation_select) the view submission payload value comes in a `selected_channel` attribute.

ie. for this input
```
input(
  "Feedback channel",
  select_menu("Channel", :channels_select, "feedback_channel")
),
```
the resulting `view.state.values` will be the following (I'm using a Workflow builder variable in the example):
```
"wgnc" => %{
    "feedback_channel" => %{
      "selected_channel" => "{{b1eab8181-8f0e-49f0-a738-697b87f8830e==channel.id}}",
      "type" => "channels_select"
    }
  }
```

This PR adds support to fetch that key in `get_submission_values`. Please let me know if you think this is the correct way to approach this.